### PR TITLE
Handle sse stream and local media playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-"# robot-audio-play" 
+# SSE Media Player
+
+Run a small Python service that listens to an SSE stream and plays media files from `/workspace/media`. When a new file is requested and exists, the current playback is stopped (if any) and the new file starts.
+
+## Requirements
+
+- Python 3.10+
+- `ffplay` from FFmpeg installed and in `PATH`
+
+## Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Environment variables (optional):
+
+- `SSE_URL`: SSE endpoint. Default `http://localhost:8000/stream`.
+- `MEDIA_DIR`: Directory containing media files. Default `/workspace/media`.
+- `PLAYER_CMD`: Player command. Default `ffplay -autoexit -nodisp -loglevel error`.
+
+You can place these in a `.env` file at repo root.
+
+## Run
+
+```bash
+python sse_player.py
+```
+
+SSE events should contain a file path (absolute or relative to `MEDIA_DIR`). 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sseclient-py==1.8.0
+python-dotenv==1.0.1
+psutil==6.0.0

--- a/sse_player.py
+++ b/sse_player.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import psutil
+from dotenv import load_dotenv
+from sseclient import SSEClient
+
+
+load_dotenv(override=False)
+MEDIA_DIR = Path(os.getenv("MEDIA_DIR", "/workspace/media")).expanduser().resolve()
+SSE_URL = os.getenv("SSE_URL", "http://localhost:8000/stream")
+PLAYER_CMD = os.getenv("PLAYER_CMD", "ffplay -autoexit -nodisp -loglevel error").split()
+
+
+class MediaPlayerManager:
+	def __init__(self) -> None:
+		self.current_process: psutil.Process | None = None
+
+	def is_playing(self) -> bool:
+		return self.current_process is not None and self.current_process.is_running() and self.current_process.status() != psutil.STATUS_ZOMBIE
+
+	def stop(self) -> None:
+		if not self.is_playing():
+			self.current_process = None
+			return
+		try:
+			proc = self.current_process
+			assert proc is not None
+			for child in proc.children(recursive=True):
+				child.terminate()
+			proc.terminate()
+			_, alive = psutil.wait_procs([proc], timeout=3)
+			for p in alive:
+				p.kill()
+		except Exception:
+			pass
+		finally:
+			self.current_process = None
+
+	def play(self, media_path: Path) -> None:
+		self.stop()
+		cmd = PLAYER_CMD + [str(media_path)]
+		process = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, preexec_fn=os.setsid)
+		self.current_process = psutil.Process(process.pid)
+
+
+def ensure_media_dir() -> None:
+	MEDIA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> int:
+	ensure_media_dir()
+	player = MediaPlayerManager()
+	print(f"Connecting to SSE server: {SSE_URL}")
+	while True:
+		try:
+			client = SSEClient(SSE_URL, retry=3000)
+			for event in client.events():
+				if not event.data:
+					continue
+				path = event.data.strip()
+				candidate = (MEDIA_DIR / path).resolve() if not Path(path).is_absolute() else Path(path).resolve()
+				if not candidate.exists():
+					print(f"[skip] File not found: {candidate}")
+					continue
+				if player.is_playing():
+					print("Stopping current playback...")
+				player.play(candidate)
+				print(f"Playing: {candidate}")
+		except KeyboardInterrupt:
+			print("Interrupted. Exiting.")
+			player.stop()
+			return 0
+		except Exception as exc:
+			print(f"SSE connection error: {exc}. Reconnecting in 3s...", file=sys.stderr)
+			time.sleep(3)
+
+
+if __name__ == "__main__":
+	sys.exit(main())


### PR DESCRIPTION
Add an SSE media player service to listen for file paths and play them from a local media directory, stopping any current playback.

---
<a href="https://cursor.com/background-agent?bcId=bc-175aaea7-f28f-407e-947f-da72f3bb99fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-175aaea7-f28f-407e-947f-da72f3bb99fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

